### PR TITLE
添加快捷设置 View 纯色背景的扩展方法

### DIFF
--- a/ktkit/src/main/java/com/hi/dhl/ktkit/ui/ViewExt.kt
+++ b/ktkit/src/main/java/com/hi/dhl/ktkit/ui/ViewExt.kt
@@ -3,7 +3,9 @@
 
 package com.hi.dhl.ktkit.ui
 
+import android.graphics.drawable.GradientDrawable
 import android.view.View
+import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -72,4 +74,22 @@ inline fun View.showActionSnackBar(
         .setAction(actionName) {
             block()
         }.show()
+}
+
+/**
+ * 快捷设置View的自定义纯色带圆角背景
+ *
+ * @receiver View
+ * @param color Int 颜色值
+ * @param cornerRadius Float 圆角 单位px
+ */
+@kotlin.internal.InlineOnly
+inline fun View.setRoundRectBg(
+    @ColorInt color: Int,
+    cornerRadius: Float = 15F
+) {
+    background = GradientDrawable().apply {
+        setColor(color)
+        setCornerRadius(cornerRadius)
+    }
 }


### PR DESCRIPTION
- 添加 `View.setRoundRectBg()` 扩展方法，能够减少创建 **shape** 文件，支持设置纯色背景和圆角。